### PR TITLE
Norqltest

### DIFF
--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -4,8 +4,7 @@
  */
 
 var r = require('rethinkdb'),
-  debug = require('debug')('connect:rethinkdb'),
-  rql = require('rql-promise');
+  debug = require('debug')('connect:rethinkdb');
 
 
 
@@ -21,16 +20,17 @@ module.exports = function (connect) {
     options.clientOptions = options.clientOptions || {};
     Store.call(this, options); // Inherit from Store
 
-    rql.connect(options.clientOptions);
 
     this.emit('connect');
     this.browserSessionsMaxAge = options.browserSessionsMaxAge || 86400000; // 1 day
     this.table = options.table || 'session';
     setInterval(function () {
       var now = (new Date()).getTime();
-      rql(r.table(this.table).filter(r.row('expires').lt(now)).delete()).
-      then(debug.bind(null, 'DELETED EXPIRED %j')).
-      done(null, debug.bind(null, 'WARNING ! COULD NOT DELETE EXPIRED !'));
+      r.connect(options.clientOptions, function (err, conn) {
+        r.table(options.table).filter(r.row('expires').lt(now)).delete().run(conn, function (err, data) {
+
+        });
+      });
     }.bind(this), options.flushOldSessIntvl || 60000);
   }
 
@@ -54,23 +54,28 @@ module.exports = function (connect) {
       session: JSON.stringify(sess)
     };
     debug('SETTING "%j" ...', sessionToStore);
-    rql(r.table(this.table).insert(sessionToStore, {
-      upsert: true
-    })).done(function (data) {
-      debug('SET %j', data);
-      fn();
-    }, function (err) {
-      fn(err);
-    });
+    r.connect(options.clientOptions, function (err, conn) {
+      r.table(options.table).insert(sessionToStore, { upsert: true }).run(conn, function (err, data) {
+        if (err) {
+          return fn(err);
+        }
+        debug('SET %j', data);
+        fn();
+      });
+    })
   };
 
   RethinkStore.prototype.destroy = function (sid, fn) {
     debug('DELETING "%s" ...', sid);
-    rql(r.table(this.table).get(sid).delete()).done(function (data) {
-      debug('DELETED %j', data);
-      fn();
-    }, function (err) {
-      fn(err);
+    r.connect(options.clientOptions, function (err, conn) {
+      r.table(options.table).get(sid).delete().run(conn, function (err, result) {
+        if (err) {
+          return fn(err);
+        }
+        debug('DELETED %j', data);
+        fn();
+
+      });
     });
   };
 

--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -7,13 +7,16 @@ var r = require('rethinkdb'),
   debug = require('debug')('connect:rethinkdb'),
   rql = require('rql-promise');
 
+
+
 module.exports = function (connect) {
 
   var Store = connect.session.Store;
+  var options = null;
 
-  function RethinkStore(options) {
+  function RethinkStore(opts) {
 
-    options = options || {};
+    options = opts || {};
     options.table = options.table || 'session';
     options.clientOptions = options.clientOptions || {};
     Store.call(this, options); // Inherit from Store

--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -27,6 +27,7 @@ module.exports = function (connect) {
     setInterval(function () {
       var now = (new Date()).getTime();
       r.connect(options.clientOptions, function (err, conn) {
+        if (err) return false;
         r.table(options.table).filter(r.row('expires').lt(now)).delete().run(conn, function (err, data) {
           conn.close();
         });
@@ -39,6 +40,7 @@ module.exports = function (connect) {
   RethinkStore.prototype.get = function (sid, fn) {
     debug('GETTING "%s" ...', sid);
     r.connect(options.clientOptions, function (err, conn) {
+      if (err) { return fn(err); }
       r.table(options.table).get(sid).run(conn, function (err, data) {
         conn.close();
         if (err) { return fn(err); }
@@ -56,11 +58,10 @@ module.exports = function (connect) {
     };
     debug('SETTING "%j" ...', sessionToStore);
     r.connect(options.clientOptions, function (err, conn) {
+      if (err) { return fn(err); }
       r.table(options.table).insert(sessionToStore, { upsert: true }).run(conn, function (err, data) {
         conn.close();
-        if (err) {
-          return fn(err);
-        }
+        if (err) { return fn(err); }
         debug('SET %j', data);
         fn();
       });
@@ -71,10 +72,9 @@ module.exports = function (connect) {
     debug('DELETING "%s" ...', sid);
     r.connect(options.clientOptions, function (err, conn) {
       r.table(options.table).get(sid).delete().run(conn, function (err, result) {
+        if (err) { return fn(err); }
         conn.close();
-        if (err) {
-          return fn(err);
-        }
+        if (err) { return fn(err); }
         debug('DELETED %j', data);
         fn();
 

--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -59,7 +59,7 @@ module.exports = function (connect) {
     debug('SETTING "%j" ...', sessionToStore);
     r.connect(options.clientOptions, function (err, conn) {
       if (err) { return fn(err); }
-      r.table(options.table).insert(sessionToStore, { upsert: true }).run(conn, function (err, data) {
+      r.table(options.table).insert(sessionToStore, { conflict: 'update' }).run(conn, function (err, data) {
         conn.close();
         if (err) { return fn(err); }
         debug('SET %j', data);

--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -14,6 +14,7 @@ module.exports = function (connect) {
   function RethinkStore(options) {
 
     options = options || {};
+    options.table = options.table || 'session';
     options.clientOptions = options.clientOptions || {};
     Store.call(this, options); // Inherit from Store
 
@@ -34,14 +35,12 @@ module.exports = function (connect) {
 
   RethinkStore.prototype.get = function (sid, fn) {
     debug('GETTING "%s" ...', sid);
-    rql(r.table(this.table).get(sid)).then(function (data) {
-      debug('GOT %j', data);
-      return data ? JSON.parse(data.session) : null;
-    }).done(function (data) {
-      debug('GOT %j', data);
-      fn(null, data);
-    }, function (err) {
-      fn(err);
+    r.connect(options.clientOptions, function (err, conn) {
+      r.table(options.table).get(sid).run(conn, function (err, data) {
+        if (err) { return fn(err); }
+        var sess = data ? JSON.parse(data.session) : null;
+        return fn(null, sess)
+      });
     });
   };
 

--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -28,7 +28,7 @@ module.exports = function (connect) {
       var now = (new Date()).getTime();
       r.connect(options.clientOptions, function (err, conn) {
         r.table(options.table).filter(r.row('expires').lt(now)).delete().run(conn, function (err, data) {
-
+          conn.close();
         });
       });
     }.bind(this), options.flushOldSessIntvl || 60000);
@@ -40,6 +40,7 @@ module.exports = function (connect) {
     debug('GETTING "%s" ...', sid);
     r.connect(options.clientOptions, function (err, conn) {
       r.table(options.table).get(sid).run(conn, function (err, data) {
+        conn.close();
         if (err) { return fn(err); }
         var sess = data ? JSON.parse(data.session) : null;
         return fn(null, sess)
@@ -56,6 +57,7 @@ module.exports = function (connect) {
     debug('SETTING "%j" ...', sessionToStore);
     r.connect(options.clientOptions, function (err, conn) {
       r.table(options.table).insert(sessionToStore, { upsert: true }).run(conn, function (err, data) {
+        conn.close();
         if (err) {
           return fn(err);
         }
@@ -69,6 +71,7 @@ module.exports = function (connect) {
     debug('DELETING "%s" ...', sid);
     r.connect(options.clientOptions, function (err, conn) {
       r.table(options.table).get(sid).delete().run(conn, function (err, result) {
+        conn.close();
         if (err) {
           return fn(err);
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "debug": "~0.7.2",
-    "rethinkdb": "~1.10.0-0",
+    "rethinkdb": "^1.13.0-2",
     "rql-promise": "~0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "debug": "~0.7.2",
     "rethinkdb": "^1.13.0-2",
-    "rql-promise": "~0.1.4"
+    "rql-promise": "^0.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "debug": "~0.7.2",
-    "rethinkdb": "^1.13.0-2"
+    "rethinkdb": "^1.14.0-0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "debug": "~0.7.2",
-    "rethinkdb": "^1.13.0-2",
-    "rql-promise": "^0.1.7"
+    "rethinkdb": "^1.13.0-2"
   }
 }


### PR DESCRIPTION
I realized that the rql-promise library no longer works with rethinkdb 1.13 and I couldn't figure out why it kept giving the error "First argument to `run` must be an open connection."

So I rewrote this library to not depend on it and simply use normal rethinkdb queries. It'd probably be better if you could fix rql-promise but I'm submitting this pull request just in case and for anyone else that wants to use connect-rethinkdb with v1.13. 
