### PR TITLE
Upgrading rethinkdb to v14

### DIFF
--- a/lib/connect-rethinkdb.js
+++ b/lib/connect-rethinkdb.js
@@ -53,7 +53,7 @@ module.exports = function (connect) {
     };
     debug('SETTING "%j" ...', sessionToStore);
     rql(r.table(this.table).insert(sessionToStore, {
-      upsert: true
+      conflict: 'update'
     })).done(function (data) {
       debug('SET %j', data);
       fn();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "debug": "~0.7.2",
-    "rethinkdb": "^1.13.0-2",
+    "rethinkdb": "^1.14.0-0",
     "rql-promise": "^0.1.7"
   }
 }


### PR DESCRIPTION
Upsert command has been removed from rethinkdb v14. 
